### PR TITLE
update URIs and badges after migration to tlsfuzzer org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pure-Python ECDSA and ECDH
 
-[![build status](https://travis-ci.org/warner/python-ecdsa.png)](http://travis-ci.org/warner/python-ecdsa)
-[![Coverage Status](https://coveralls.io/repos/warner/python-ecdsa/badge.svg)](https://coveralls.io/r/warner/python-ecdsa)
-[![condition coverage](https://img.shields.io/badge/condition%20coverage-81%25-yellow)](https://travis-ci.org/warner/python-ecdsa/jobs/626479178#L776)
+[![Build Status](https://travis-ci.com/tlsfuzzer/python-ecdsa.svg?branch=master)](https://travis-ci.com/tlsfuzzer/python-ecdsa)
+[![Coverage Status](https://coveralls.io/repos/github/tlsfuzzer/python-ecdsa/badge.svg?branch=master)](https://coveralls.io/github/tlsfuzzer/python-ecdsa?branch=master)
+[![condition coverage](https://img.shields.io/badge/condition%20coverage-84%25-yellow)](https://travis-ci.com/github/tlsfuzzer/python-ecdsa/jobs/456999547#L586)
 [![Latest Version](https://img.shields.io/pypi/v/ecdsa.svg?style=flat)](https://pypi.python.org/pypi/ecdsa/)
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Brian Warner",
     author_email="warner@lothar.com",
-    url="http://github.com/warner/python-ecdsa",
+    url="http://github.com/tlsfuzzer/python-ecdsa",
     packages=["ecdsa"],
     package_dir={"": "src"},
     license="MIT",

--- a/src/ecdsa/__init__.py
+++ b/src/ecdsa/__init__.py
@@ -33,7 +33,7 @@ from .ecdh import (
 )
 from .der import UnexpectedDER
 
-# This code comes from http://github.com/warner/python-ecdsa
+# This code comes from http://github.com/tlsfuzzer/python-ecdsa
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/src/ecdsa/numbertheory.py
+++ b/src/ecdsa/numbertheory.py
@@ -387,7 +387,7 @@ def phi(n):  # pragma: no cover
     warnings.warn(
         "Function is unused by library code. If you use this code, "
         "please open an issue in "
-        "https://github.com/warner/python-ecdsa",
+        "https://github.com/tlsfuzzer/python-ecdsa",
         DeprecationWarning,
     )
 
@@ -417,7 +417,7 @@ def carmichael(n):  # pragma: no cover
     warnings.warn(
         "Function is unused by library code. If you use this code, "
         "please open an issue in "
-        "https://github.com/warner/python-ecdsa",
+        "https://github.com/tlsfuzzer/python-ecdsa",
         DeprecationWarning,
     )
 
@@ -432,7 +432,7 @@ def carmichael_of_factorized(f_list):  # pragma: no cover
     warnings.warn(
         "Function is unused by library code. If you use this code, "
         "please open an issue in "
-        "https://github.com/warner/python-ecdsa",
+        "https://github.com/tlsfuzzer/python-ecdsa",
         DeprecationWarning,
     )
 
@@ -452,7 +452,7 @@ def carmichael_of_ppower(pp):  # pragma: no cover
     warnings.warn(
         "Function is unused by library code. If you use this code, "
         "please open an issue in "
-        "https://github.com/warner/python-ecdsa",
+        "https://github.com/tlsfuzzer/python-ecdsa",
         DeprecationWarning,
     )
 
@@ -469,7 +469,7 @@ def order_mod(x, m):  # pragma: no cover
     warnings.warn(
         "Function is unused by library code. If you use this code, "
         "please open an issue in "
-        "https://github.com/warner/python-ecdsa",
+        "https://github.com/tlsfuzzer/python-ecdsa",
         DeprecationWarning,
     )
 
@@ -495,7 +495,7 @@ def largest_factor_relatively_prime(a, b):  # pragma: no cover
     warnings.warn(
         "Function is unused by library code. If you use this code, "
         "please open an issue in "
-        "https://github.com/warner/python-ecdsa",
+        "https://github.com/tlsfuzzer/python-ecdsa",
         DeprecationWarning,
     )
 
@@ -520,7 +520,7 @@ def kinda_order_mod(x, m):  # pragma: no cover
     warnings.warn(
         "Function is unused by library code. If you use this code, "
         "please open an issue in "
-        "https://github.com/warner/python-ecdsa",
+        "https://github.com/tlsfuzzer/python-ecdsa",
         DeprecationWarning,
     )
 


### PR DESCRIPTION
Adjust links after migration to tlsfuzzer organisation and migration from Travis-CI.org to Travis-CI.com

fixes #226