### PR TITLE
Fix (in)equality tests

### DIFF
--- a/src/ecdsa/ecdsa.py
+++ b/src/ecdsa/ecdsa.py
@@ -145,10 +145,19 @@ class Public_key(object):
             raise InvalidPointError("Generator point order is bad.")
 
     def __eq__(self, other):
+        """Return True if the keys are identical, False otherwise.
+
+        Note: for comparison, only placement on the same curve and point
+        equality is considered, use of the same generator point is not
+        considered.
+        """
         if isinstance(other, Public_key):
-            """Return True if the points are identical, False otherwise."""
             return self.curve == other.curve and self.point == other.point
         return NotImplemented
+
+    def __ne__(self, other):
+        """Return False if the keys are identical, True otherwise."""
+        return not self == other
 
     def verifies(self, hash, signature):
         """Verify that signature is a valid signature of hash.
@@ -188,13 +197,17 @@ class Private_key(object):
         self.secret_multiplier = secret_multiplier
 
     def __eq__(self, other):
+        """Return True if the points are identical, False otherwise."""
         if isinstance(other, Private_key):
-            """Return True if the points are identical, False otherwise."""
             return (
                 self.public_key == other.public_key
                 and self.secret_multiplier == other.secret_multiplier
             )
         return NotImplemented
+
+    def __ne__(self, other):
+        """Return False if the points are identical, True otherwise."""
+        return not self == other
 
     def sign(self, hash, random_k):
         """Return a signature for the provided hash, using the provided

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -191,6 +191,10 @@ class VerifyingKey(object):
             return self.curve == other.curve and self.pubkey == other.pubkey
         return NotImplemented
 
+    def __ne__(self, other):
+        """Return False if the points are identical, True otherwise."""
+        return not self == other
+
     @classmethod
     def from_public_point(
         cls, point, curve=NIST192p, hashfunc=sha1, validate_point=True
@@ -816,6 +820,10 @@ class SigningKey(object):
                 and self.privkey == other.privkey
             )
         return NotImplemented
+
+    def __ne__(self, other):
+        """Return False if the points are identical, True otherwise."""
+        return not self == other
 
     @classmethod
     def generate(cls, curve=NIST192p, entropy=None, hashfunc=sha1):

--- a/src/ecdsa/test_der.py
+++ b/src/ecdsa/test_der.py
@@ -42,7 +42,7 @@ class TestRemoveInteger(unittest.TestCase):
         val, rem = remove_integer(b("\x02\x02\x00\x80"))
 
         self.assertEqual(val, 0x80)
-        self.assertFalse(rem)
+        self.assertEqual(rem, b"")
 
     def test_two_zero_bytes_with_high_bit_set(self):
         with self.assertRaises(UnexpectedDER):
@@ -60,19 +60,19 @@ class TestRemoveInteger(unittest.TestCase):
         val, rem = remove_integer(b("\x02\x01\x00"))
 
         self.assertEqual(val, 0)
-        self.assertFalse(rem)
+        self.assertEqual(rem, b"")
 
     def test_encoding_of_127(self):
         val, rem = remove_integer(b("\x02\x01\x7f"))
 
         self.assertEqual(val, 127)
-        self.assertFalse(rem)
+        self.assertEqual(rem, b"")
 
     def test_encoding_of_128(self):
         val, rem = remove_integer(b("\x02\x02\x00\x80"))
 
         self.assertEqual(val, 128)
-        self.assertFalse(rem)
+        self.assertEqual(rem, b"")
 
     def test_wrong_tag(self):
         with self.assertRaises(UnexpectedDER) as e:

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -198,20 +198,16 @@ class TestVerifyingKeyFromDer(unittest.TestCase):
         self.assertEqual(self.vk, self.sk.get_verifying_key())
 
     def test_inequality_on_verifying_keys(self):
-        # use `==` to workaround instrumental <-> unittest compat issue
-        self.assertFalse(self.vk == self.vk2)
+        self.assertNotEqual(self.vk, self.vk2)
 
     def test_inequality_on_verifying_keys_not_implemented(self):
-        # use `==` to workaround instrumental <-> unittest compat issue
-        self.assertFalse(self.vk == None)
+        self.assertNotEqual(self.vk, None)
 
     def test_VerifyingKey_inequality_on_same_curve(self):
-        # use `==` to workaround instrumental <-> unittest compat issue
-        self.assertFalse(self.vk == self.sk2.verifying_key)
+        self.assertNotEqual(self.vk, self.sk2.verifying_key)
 
     def test_SigningKey_inequality_on_same_curve(self):
-        # use `==` to workaround instrumental <-> unittest compat issue
-        self.assertFalse(self.sk == self.sk2)
+        self.assertNotEqual(self.sk, self.sk2)
 
 
 class TestSigningKey(unittest.TestCase):
@@ -283,12 +279,10 @@ class TestSigningKey(unittest.TestCase):
         self.assertTrue(vk.verify(sig, b"other message"))
 
     def test_inequality_on_signing_keys(self):
-        # use `==` to workaround instrumental <-> unittest compat issue
-        self.assertFalse(self.sk1 == self.sk2)
+        self.assertNotEqual(self.sk1, self.sk2)
 
     def test_inequality_on_signing_keys_not_implemented(self):
-        # use `==` to workaround instrumental <-> unittest compat issue
-        self.assertFalse(self.sk1 == None)
+        self.assertNotEqual(self.sk1, None)
 
 
 # test VerifyingKey.verify()

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -653,9 +653,9 @@ class ECDSA(unittest.TestCase):
             )
 
         # Test if original vk is the list of recovered keys
-        self.assertTrue(
-            vk.pubkey.point
-            in [recovered_vk.pubkey.point for recovered_vk in recovered_vks]
+        self.assertIn(
+            vk.pubkey.point,
+            [recovered_vk.pubkey.point for recovered_vk in recovered_vks],
         )
 
     def test_public_key_recovery_with_custom_hash(self):
@@ -684,9 +684,9 @@ class ECDSA(unittest.TestCase):
             self.assertEqual(sha256, recovered_vk.default_hashfunc)
 
         # Test if original vk is the list of recovered keys
-        self.assertTrue(
-            vk.pubkey.point
-            in [recovered_vk.pubkey.point for recovered_vk in recovered_vks]
+        self.assertIn(
+            vk.pubkey.point,
+            [recovered_vk.pubkey.point for recovered_vk in recovered_vks],
         )
 
     def test_encoding(self):


### PR DESCRIPTION
fixes #227 
on python2 `__ne__` needs to be implemented for every `__eq__` defined, otherwise `assertNotEqual` and reflection doesn't work