### PR TITLE
implement lock-less algorithm in PointJacobi

### DIFF
--- a/src/ecdsa/test_rw_lock.py
+++ b/src/ecdsa/test_rw_lock.py
@@ -2,7 +2,10 @@
 # https://code.activestate.com/recipes/577803-reader-writer-lock-with-priority-for-writers/
 # released under the MIT licence
 
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import threading
 import time
 import copy


### PR DESCRIPTION
since both __coords and __precompute have a "final" state, we can easily
implement lock-less handling of those parameters by depending on GIL
(the atomicity of single bytecode instructions)

fixes #238
closes #239 (this in an alternative, simpler approach)