### PR TITLE
allow limiting point formats, don't accept malformed PEM public files

### DIFF
--- a/src/ecdsa/ecdh.py
+++ b/src/ecdsa/ecdh.py
@@ -216,7 +216,7 @@ class ECDH(object):
 
         :return: public (verifying) key from local private key.
         :rtype: VerifyingKey object
-       """
+        """
         return self.private_key.get_verifying_key()
 
     def load_received_public_key(self, public_key):
@@ -237,7 +237,9 @@ class ECDH(object):
             raise InvalidCurveError("Curve mismatch.")
         self.public_key = public_key
 
-    def load_received_public_key_bytes(self, public_key_str):
+    def load_received_public_key_bytes(
+        self, public_key_str, valid_encodings=None
+    ):
         """
         Load public key from byte string.
 
@@ -247,9 +249,16 @@ class ECDH(object):
 
         :param public_key_str: public key in bytes string format
         :type public_key_str: :term:`bytes-like object`
+        :param valid_encodings: list of acceptable point encoding formats,
+            supported ones are: :term:`uncompressed`, :term:`compressed`,
+            :term:`hybrid`, and :term:`raw encoding` (specified with ``raw``
+            name). All formats by default (specified with ``None``).
+        :type valid_encodings: :term:`set-like object`
         """
         return self.load_received_public_key(
-            VerifyingKey.from_string(public_key_str, self.curve)
+            VerifyingKey.from_string(
+                public_key_str, self.curve, valid_encodings
+            )
         )
 
     def load_received_public_key_der(self, public_key_der):

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -13,7 +13,7 @@ import array
 import pytest
 import hashlib
 
-from .keys import VerifyingKey, SigningKey
+from .keys import VerifyingKey, SigningKey, MalformedPointError
 from .der import unpem
 from .util import (
     sigencode_string,
@@ -152,6 +152,12 @@ class TestVerifyingKeyFromDer(unittest.TestCase):
         cls.vk2 = VerifyingKey.from_pem(key_str)
 
         cls.sk2 = SigningKey.generate(vk.curve)
+
+    def test_load_key_with_disabled_format(self):
+        with self.assertRaises(MalformedPointError) as e:
+            VerifyingKey.from_der(self.key_bytes, valid_encodings=["raw"])
+
+        self.assertIn("enabled (raw) encodings", str(e.exception))
 
     def test_custom_hashfunc(self):
         vk = VerifyingKey.from_der(self.key_bytes, hashlib.sha256)


### PR DESCRIPTION
Allow specifying what point formats are supported when loading public
keys. Limit the point formats when loading PEM and DER public files
to the formats actually allowed in them: uncompressed, compressed,
and hybrid. Previous code would allow raw encoding too.

fixes #214