### PR TITLE
Support explicit curve params

### DIFF
--- a/build-requirements-3.4.txt
+++ b/build-requirements-3.4.txt
@@ -4,3 +4,4 @@ hypothesis
 pytest>=4.6.0
 PyYAML<5.3
 coverage
+attrs<21

--- a/src/ecdsa/curves.py
+++ b/src/ecdsa/curves.py
@@ -1,7 +1,8 @@
 from __future__ import division
 
-from . import der, ecdsa
-from .util import orderlen
+from . import der, ecdsa, ellipticcurve
+from .util import orderlen, number_to_string, string_to_number
+from ._compat import normalise_bytes
 
 
 # orderlen was defined in this module previously, so keep it in __all__,
@@ -29,7 +30,13 @@ __all__ = [
     "BRAINPOOLP320r1",
     "BRAINPOOLP384r1",
     "BRAINPOOLP512r1",
+    "PRIME_FIELD_OID",
+    "CHARACTERISTIC_TWO_FIELD_OID",
 ]
+
+
+PRIME_FIELD_OID = (1, 2, 840, 10045, 1, 1)
+CHARACTERISTIC_TWO_FIELD_OID = (1, 2, 840, 10045, 1, 2)
 
 
 class UnknownCurveError(Exception):
@@ -47,10 +54,141 @@ class Curve:
         self.verifying_key_length = 2 * orderlen(curve.p())
         self.signature_length = 2 * self.baselen
         self.oid = oid
-        self.encoded_oid = der.encode_oid(*oid)
+        if oid:
+            self.encoded_oid = der.encode_oid(*oid)
+
+    def __eq__(self, other):
+        if isinstance(other, Curve):
+            return (
+                self.curve == other.curve and self.generator == other.generator
+            )
+        return NotImplemented
+
+    def __ne__(self, other):
+        return not self == other
 
     def __repr__(self):
         return self.name
+
+    def to_der(self, encoding=None, point_encoding="uncompressed"):
+        """Serialise the curve parameters to binary string.
+
+        :param str encoding: the format to save the curve parameters in.
+            Default is ``named_curve``, with fallback being the ``explicit``
+            if the OID is not set for the curve.
+        :param str point_encoding: the point encoding of the generator when
+            explicit curve encoding is used. Ignored for ``named_curve``
+            format.
+        """
+        if encoding is None:
+            if self.oid:
+                encoding = "named_curve"
+            else:
+                encoding = "explicit"
+
+        if encoding == "named_curve":
+            if not self.oid:
+                raise UnknownCurveError(
+                    "Can't encode curve using named_curve encoding without "
+                    "associated curve OID"
+                )
+            return der.encode_oid(*self.oid)
+
+        # encode the ECParameters sequence
+        curve_p = self.curve.p()
+        version = der.encode_integer(1)
+        field_id = der.encode_sequence(
+            der.encode_oid(*PRIME_FIELD_OID), der.encode_integer(curve_p)
+        )
+        curve = der.encode_sequence(
+            der.encode_octet_string(
+                number_to_string(self.curve.a() % curve_p, curve_p)
+            ),
+            der.encode_octet_string(
+                number_to_string(self.curve.b() % curve_p, curve_p)
+            ),
+        )
+        base = der.encode_octet_string(self.generator.to_bytes(point_encoding))
+        order = der.encode_integer(self.generator.order())
+        seq_elements = [version, field_id, curve, base, order]
+        if self.curve.cofactor():
+            cofactor = der.encode_integer(self.curve.cofactor())
+            seq_elements.append(cofactor)
+
+        return der.encode_sequence(*seq_elements)
+
+    @staticmethod
+    def from_der(data):
+        """Decode the curve parameters from DER file.
+
+        :param data: the binary string to decode the parameters from
+        :type data: bytes-like object
+        """
+        data = normalise_bytes(data)
+        if not der.is_sequence(data):
+            oid, empty = der.remove_object(data)
+            if empty:
+                raise der.UnexpectedDER("Unexpected data after OID")
+            return find_curve(oid)
+
+        seq, empty = der.remove_sequence(data)
+        if empty:
+            raise der.UnexpectedDER(
+                "Unexpected data after ECParameters structure"
+            )
+        # decode the ECParameters sequence
+        version, rest = der.remove_integer(seq)
+        if version != 1:
+            raise der.UnexpectedDER("Unknown parameter encoding format")
+        field_id, rest = der.remove_sequence(rest)
+        curve, rest = der.remove_sequence(rest)
+        base_bytes, rest = der.remove_octet_string(rest)
+        order, rest = der.remove_integer(rest)
+        cofactor = None
+        if rest:
+            cofactor, rest = der.remove_integer(rest)
+
+        # decode the ECParameters.fieldID sequence
+        field_type, rest = der.remove_object(field_id)
+        if field_type == CHARACTERISTIC_TWO_FIELD_OID:
+            raise UnknownCurveError("Characteristic 2 curves unsupported")
+        if field_type != PRIME_FIELD_OID:
+            raise UnknownCurveError(
+                "Unknown field type: {0}".format(field_type)
+            )
+        prime, empty = der.remove_integer(rest)
+        if empty:
+            raise der.UnexpectedDER(
+                "Unexpected data after ECParameters.fieldID.Prime-p element"
+            )
+
+        # decode the ECParameters.curve sequence
+        curve_a_bytes, rest = der.remove_octet_string(curve)
+        curve_b_bytes, rest = der.remove_octet_string(rest)
+        # seed can be defined here, but we don't parse it, so ignore `rest`
+
+        curve_a = string_to_number(curve_a_bytes)
+        curve_b = string_to_number(curve_b_bytes)
+
+        curve_fp = ellipticcurve.CurveFp(prime, curve_a, curve_b, cofactor)
+
+        # decode the ECParameters.base point
+
+        base = ellipticcurve.PointJacobi.from_bytes(
+            curve_fp,
+            base_bytes,
+            valid_encodings=("uncompressed", "compressed", "hybrid"),
+            order=order,
+            generator=True,
+        )
+        tmp_curve = Curve("unknown", curve_fp, base, None)
+
+        # if the curve matches one of the well-known ones, use the well-known
+        # one in preference, as it will have the OID and name associated
+        for i in curves:
+            if tmp_curve == i:
+                return i
+        return tmp_curve
 
 
 # the SEC curves

--- a/src/ecdsa/errors.py
+++ b/src/ecdsa/errors.py
@@ -1,0 +1,6 @@
+class MalformedPointError(AssertionError):
+    """Raised in case the encoding of private or public key is malformed."""
+
+    pass
+
+

--- a/src/ecdsa/errors.py
+++ b/src/ecdsa/errors.py
@@ -2,5 +2,3 @@ class MalformedPointError(AssertionError):
     """Raised in case the encoding of private or public key is malformed."""
 
     pass
-
-

--- a/src/ecdsa/test_curves.py
+++ b/src/ecdsa/test_curves.py
@@ -24,6 +24,45 @@ class TestParameterEncoding(unittest.TestCase):
             "AiEA/////wAAAAD//////////7zm+q2nF56E87nKwvxjJVECAQE="
         )
 
+    def test_from_pem(self):
+        pem_params = (
+            "-----BEGIN EC PARAMETERS-----\n"
+            "MIHgAgEBMCwGByqGSM49AQECIQD/////AAAAAQAAAAAAAAAAAAAAAP/////////\n"
+            "//////zBEBCD/////AAAAAQAAAAAAAAAAAAAAAP///////////////AQgWsY12K\n"
+            "o6k+ez671VdpiGvGUdBrDMU7D2O848PifSYEsEQQRrF9Hy4SxCR/i85uVjpEDyd\n"
+            "wN9gS3rM6D0oTlF2JjClk/jQuL+Gn+bjufrSnwPnhYrzjNXazFezsu2QGg3v1H1\n"
+            "AiEA/////wAAAAD//////////7zm+q2nF56E87nKwvxjJVECAQE=\n"
+            "-----END EC PARAMETERS-----\n"
+        )
+        curve = Curve.from_pem(pem_params)
+
+        self.assertIs(curve, NIST256p)
+
+    def test_from_pem_with_wrong_header(self):
+        pem_params = (
+            "-----BEGIN PARAMETERS-----\n"
+            "MIHgAgEBMCwGByqGSM49AQECIQD/////AAAAAQAAAAAAAAAAAAAAAP/////////\n"
+            "//////zBEBCD/////AAAAAQAAAAAAAAAAAAAAAP///////////////AQgWsY12K\n"
+            "o6k+ez671VdpiGvGUdBrDMU7D2O848PifSYEsEQQRrF9Hy4SxCR/i85uVjpEDyd\n"
+            "wN9gS3rM6D0oTlF2JjClk/jQuL+Gn+bjufrSnwPnhYrzjNXazFezsu2QGg3v1H1\n"
+            "AiEA/////wAAAAD//////////7zm+q2nF56E87nKwvxjJVECAQE=\n"
+            "-----END PARAMETERS-----\n"
+        )
+        with self.assertRaises(der.UnexpectedDER) as e:
+            Curve.from_pem(pem_params)
+
+        self.assertIn("PARAMETERS PEM header", str(e.exception))
+
+    def test_to_pem(self):
+        pem_params = (
+            b"-----BEGIN EC PARAMETERS-----\n"
+            b"BggqhkjOPQMBBw==\n"
+            b"-----END EC PARAMETERS-----\n"
+        )
+        encoding = NIST256p.to_pem()
+
+        self.assertEqual(pem_params, encoding)
+
     def test_compare_with_different_object(self):
         self.assertNotEqual(NIST256p, 256)
 

--- a/src/ecdsa/test_curves.py
+++ b/src/ecdsa/test_curves.py
@@ -1,0 +1,239 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import base64
+import pytest
+from .curves import Curve, NIST256p, curves, UnknownCurveError, PRIME_FIELD_OID
+from .ellipticcurve import CurveFp, PointJacobi
+from . import der
+from .util import number_to_string
+
+
+class TestParameterEncoding(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # minimal, but with cofactor (excludes seed when compared to
+        # OpenSSL output)
+        cls.base64_params = (
+            "MIHgAgEBMCwGByqGSM49AQECIQD/////AAAAAQAAAAAAAAAAAAAAAP/////////"
+            "//////zBEBCD/////AAAAAQAAAAAAAAAAAAAAAP///////////////AQgWsY12K"
+            "o6k+ez671VdpiGvGUdBrDMU7D2O848PifSYEsEQQRrF9Hy4SxCR/i85uVjpEDyd"
+            "wN9gS3rM6D0oTlF2JjClk/jQuL+Gn+bjufrSnwPnhYrzjNXazFezsu2QGg3v1H1"
+            "AiEA/////wAAAAD//////////7zm+q2nF56E87nKwvxjJVECAQE="
+        )
+
+    def test_compare_with_different_object(self):
+        self.assertNotEqual(NIST256p, 256)
+
+    def test_named_curve_params_der(self):
+        encoded = NIST256p.to_der()
+
+        # just the encoding of the NIST256p OID (prime256v1)
+        self.assertEqual(b"\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07", encoded)
+
+    def test_verify_that_default_is_named_curve_der(self):
+        encoded_default = NIST256p.to_der()
+        encoded_named = NIST256p.to_der("named_curve")
+
+        self.assertEqual(encoded_default, encoded_named)
+
+    def test_encoding_to_explicit_params(self):
+        encoded = NIST256p.to_der("explicit")
+
+        self.assertEqual(encoded, bytes(base64.b64decode(self.base64_params)))
+
+    def test_encoding_to_explicit_compressed_params(self):
+        encoded = NIST256p.to_der("explicit", "compressed")
+
+        compressed_base_point = (
+            "MIHAAgEBMCwGByqGSM49AQECIQD/////AAAAAQAAAAAAAAAAAAAAAP//////////"
+            "/////zBEBCD/////AAAAAQAAAAAAAAAAAAAAAP///////////////AQgWsY12Ko6"
+            "k+ez671VdpiGvGUdBrDMU7D2O848PifSYEsEIQNrF9Hy4SxCR/i85uVjpEDydwN9"
+            "gS3rM6D0oTlF2JjClgIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8YyVR"
+            "AgEB"
+        )
+
+        self.assertEqual(
+            encoded, bytes(base64.b64decode(compressed_base_point))
+        )
+
+    def test_decoding_explicit_from_openssl(self):
+        # generated with openssl 1.1.1k using
+        # openssl ecparam -name P-256 -param_enc explicit -out /tmp/file.pem
+        p256_explicit = (
+            "MIH3AgEBMCwGByqGSM49AQECIQD/////AAAAAQAAAAAAAAAAAAAAAP//////////"
+            "/////zBbBCD/////AAAAAQAAAAAAAAAAAAAAAP///////////////AQgWsY12Ko6"
+            "k+ez671VdpiGvGUdBrDMU7D2O848PifSYEsDFQDEnTYIhucEk2pmeOETnSa3gZ9+"
+            "kARBBGsX0fLhLEJH+Lzm5WOkQPJ3A32BLeszoPShOUXYmMKWT+NC4v4af5uO5+tK"
+            "fA+eFivOM1drMV7Oy7ZAaDe/UfUCIQD/////AAAAAP//////////vOb6racXnoTz"
+            "ucrC/GMlUQIBAQ=="
+        )
+
+        decoded = Curve.from_der(bytes(base64.b64decode(p256_explicit)))
+
+        self.assertEqual(NIST256p, decoded)
+
+    def test_decoding_well_known_from_explicit_params(self):
+        curve = Curve.from_der(bytes(base64.b64decode(self.base64_params)))
+
+        self.assertIs(curve, NIST256p)
+
+    def test_compare_curves_with_different_generators(self):
+        curve_fp = CurveFp(23, 1, 7)
+        base_a = PointJacobi(curve_fp, 13, 3, 1, 9, generator=True)
+        base_b = PointJacobi(curve_fp, 1, 20, 1, 9, generator=True)
+
+        curve_a = Curve("unknown", curve_fp, base_a, None)
+        curve_b = Curve("unknown", curve_fp, base_b, None)
+
+        self.assertNotEqual(curve_a, curve_b)
+
+    def test_default_encode_for_custom_curve(self):
+        curve_fp = CurveFp(23, 1, 7)
+        base_point = PointJacobi(curve_fp, 13, 3, 1, 9, generator=True)
+
+        curve = Curve("unknown", curve_fp, base_point, None)
+
+        encoded = curve.to_der()
+
+        decoded = Curve.from_der(encoded)
+
+        self.assertEqual(curve, decoded)
+
+        expected = "MCECAQEwDAYHKoZIzj0BAQIBFzAGBAEBBAEHBAMEDQMCAQk="
+
+        self.assertEqual(encoded, bytes(base64.b64decode(expected)))
+
+    def test_named_curve_encode_for_custom_curve(self):
+        curve_fp = CurveFp(23, 1, 7)
+        base_point = PointJacobi(curve_fp, 13, 3, 1, 9, generator=True)
+
+        curve = Curve("unknown", curve_fp, base_point, None)
+
+        with self.assertRaises(UnknownCurveError) as e:
+            curve.to_der("named_curve")
+
+        self.assertIn("Can't encode curve", str(e.exception))
+
+    def test_try_decoding_binary_explicit(self):
+        sect113r1_explicit = (
+            "MIGRAgEBMBwGByqGSM49AQIwEQIBcQYJKoZIzj0BAgMCAgEJMDkEDwAwiCUMpufH"
+            "/mSc6Fgg9wQPAOi+5NPiJgdEGIvg6ccjAxUAEOcjqxTWluZ2h1YVF1b+v4/LSakE"
+            "HwQAnXNhbzX0qxQH1zViwQ8ApSgwJ3lY7oTRMV7TGIYCDwEAAAAAAAAA2czsijnl"
+            "bwIBAg=="
+        )
+
+        with self.assertRaises(UnknownCurveError) as e:
+            Curve.from_der(base64.b64decode(sect113r1_explicit))
+
+        self.assertIn("Characteristic 2 curves unsupported", str(e.exception))
+
+    def test_decode_malformed_named_curve(self):
+        bad_der = der.encode_oid(*NIST256p.oid) + der.encode_integer(1)
+
+        with self.assertRaises(der.UnexpectedDER) as e:
+            Curve.from_der(bad_der)
+
+        self.assertIn("Unexpected data after OID", str(e.exception))
+
+    def test_decode_malformed_explicit_garbage_after_ECParam(self):
+        bad_der = bytes(
+            base64.b64decode(self.base64_params)
+        ) + der.encode_integer(1)
+
+        with self.assertRaises(der.UnexpectedDER) as e:
+            Curve.from_der(bad_der)
+
+        self.assertIn("Unexpected data after ECParameters", str(e.exception))
+
+    def test_decode_malformed_unknown_version_number(self):
+        bad_der = der.encode_sequence(der.encode_integer(2))
+
+        with self.assertRaises(der.UnexpectedDER) as e:
+            Curve.from_der(bad_der)
+
+        self.assertIn("Unknown parameter encoding format", str(e.exception))
+
+    def test_decode_malformed_unknown_field_type(self):
+        curve_p = NIST256p.curve.p()
+        bad_der = der.encode_sequence(
+            der.encode_integer(1),
+            der.encode_sequence(
+                der.encode_oid(1, 2, 3), der.encode_integer(curve_p)
+            ),
+            der.encode_sequence(
+                der.encode_octet_string(
+                    number_to_string(NIST256p.curve.a() % curve_p, curve_p)
+                ),
+                der.encode_octet_string(
+                    number_to_string(NIST256p.curve.b(), curve_p)
+                ),
+            ),
+            der.encode_octet_string(
+                NIST256p.generator.to_bytes("uncompressed")
+            ),
+            der.encode_integer(NIST256p.generator.order()),
+        )
+
+        with self.assertRaises(UnknownCurveError) as e:
+            Curve.from_der(bad_der)
+
+        self.assertIn("Unknown field type: (1, 2, 3)", str(e.exception))
+
+    def test_decode_malformed_garbage_after_prime(self):
+        curve_p = NIST256p.curve.p()
+        bad_der = der.encode_sequence(
+            der.encode_integer(1),
+            der.encode_sequence(
+                der.encode_oid(*PRIME_FIELD_OID),
+                der.encode_integer(curve_p),
+                der.encode_integer(1),
+            ),
+            der.encode_sequence(
+                der.encode_octet_string(
+                    number_to_string(NIST256p.curve.a() % curve_p, curve_p)
+                ),
+                der.encode_octet_string(
+                    number_to_string(NIST256p.curve.b(), curve_p)
+                ),
+            ),
+            der.encode_octet_string(
+                NIST256p.generator.to_bytes("uncompressed")
+            ),
+            der.encode_integer(NIST256p.generator.order()),
+        )
+
+        with self.assertRaises(der.UnexpectedDER) as e:
+            Curve.from_der(bad_der)
+
+        self.assertIn("Prime-p element", str(e.exception))
+
+
+@pytest.mark.parametrize("curve", curves, ids=[i.name for i in curves])
+def test_curve_params_encode_decode_named(curve):
+    ret = Curve.from_der(curve.to_der("named_curve"))
+
+    assert curve == ret
+
+
+@pytest.mark.parametrize("curve", curves, ids=[i.name for i in curves])
+def test_curve_params_encode_decode_explicit(curve):
+    ret = Curve.from_der(curve.to_der("explicit"))
+
+    assert curve == ret
+
+
+@pytest.mark.parametrize("curve", curves, ids=[i.name for i in curves])
+def test_curve_params_encode_decode_default(curve):
+    ret = Curve.from_der(curve.to_der())
+
+    assert curve == ret
+
+
+@pytest.mark.parametrize("curve", curves, ids=[i.name for i in curves])
+def test_curve_params_encode_decode_explicit_compressed(curve):
+    ret = Curve.from_der(curve.to_der("explicit", "compressed"))
+
+    assert curve == ret

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -1319,10 +1319,34 @@ class OpenSSL(unittest.TestCase):
             % mdarg
         )
 
+        with open("t/privkey-explicit.pem", "wb") as e:
+            e.write(sk.to_pem(curve_parameters_encoding="explicit"))
+        run_openssl(
+            "dgst %s -sign t/privkey-explicit.pem -out t/data.sig2 t/data.txt"
+            % mdarg
+        )
+        run_openssl(
+            "dgst %s -verify t/pubkey.pem -signature t/data.sig2 t/data.txt"
+            % mdarg
+        )
+
         with open("t/privkey-p8.pem", "wb") as e:
             e.write(sk.to_pem(format="pkcs8"))
         run_openssl(
             "dgst %s -sign t/privkey-p8.pem -out t/data.sig3 t/data.txt"
+            % mdarg
+        )
+        run_openssl(
+            "dgst %s -verify t/pubkey.pem -signature t/data.sig3 t/data.txt"
+            % mdarg
+        )
+
+        with open("t/privkey-p8-explicit.pem", "wb") as e:
+            e.write(
+                sk.to_pem(format="pkcs8", curve_parameters_encoding="explicit")
+            )
+        run_openssl(
+            "dgst %s -sign t/privkey-p8-explicit.pem -out t/data.sig3 t/data.txt"
             % mdarg
         )
         run_openssl(

--- a/src/ecdsa/test_pyecdsa.py
+++ b/src/ecdsa/test_pyecdsa.py
@@ -745,6 +745,12 @@ class ECDSA(unittest.TestCase):
 
         self.assertIn("hybrid", str(exp.exception))
 
+    def test_decoding_with_unknown_format(self):
+        with self.assertRaises(ValueError) as e:
+            VerifyingKey.from_string(b"", valid_encodings=("raw", "foobar"))
+
+        self.assertIn("Only uncompressed, compressed", str(e.exception))
+
     def test_uncompressed_decoding_with_blocked_format(self):
         enc = b(
             "\x04"

--- a/tox.ini
+++ b/tox.ini
@@ -96,6 +96,13 @@ commands =
          flake8 setup.py speed.py src
          black --check --line-length 79 .
 
+[testenv:codeformat]
+basepython = python3
+deps =
+     black==19.10b0
+commands =
+         black --line-length 79 .
+
 [flake8]
 exclude = src/ecdsa/test*.py
 # We're just getting started. For now, ignore the following problems:

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
      py{33}: hypothesis<3.44
      py{26}: unittest2
      py{26}: hypothesis<3
+     py{34}: attrs<21
      py{26,27,34,35,36,37,38,39,py,py3}: pytest
      py{27,34,35,36,37,38,39,py,py3}: hypothesis
      gmpy2py{27,39}: gmpy2


### PR DESCRIPTION
Add support for reading and writing curve parameters.

TODO:
 - [x] reading and writing DER EC params
 - [x] reading and writing PEM EC params
 - [x] reading and writing VerifyingKey with explicit params
 - [x] reading and writing SigningKey with explicit params

fixes #39 