### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/ecdsa/ellipticcurve.py
+++ b/src/ecdsa/ellipticcurve.py
@@ -1274,7 +1274,7 @@ class PointEdwards(AbstractPoint):
 
     def __init__(self, curve, x, y, z, t, order=None):
         """
-        Initialise a point that uses the extended coordinates interanlly.
+        Initialise a point that uses the extended coordinates internally.
         """
         super(PointEdwards, self).__init__()
         self.__curve = curve

--- a/src/ecdsa/numbertheory.py
+++ b/src/ecdsa/numbertheory.py
@@ -7,7 +7,7 @@
 # Written in 2005 and 2006 by Peter Pearson and placed in the public domain.
 # Revision history:
 #   2008.11.14: Use pow(base, exponent, modulus) for modular_exp.
-#               Make gcd and lcm accept arbitrarly many arguments.
+#               Make gcd and lcm accept arbitrarily many arguments.
 
 from __future__ import division
 

--- a/src/ecdsa/test_malformed_sigs.py
+++ b/src/ecdsa/test_malformed_sigs.py
@@ -174,7 +174,7 @@ def st_random_der_ecdsa_sig_value(draw):
     note("Configuration: {0}".format(name))
     order = int(verifying_key.curve.order)
 
-    # the encode_integer doesn't suport negative numbers, would be nice
+    # the encode_integer doesn't support negative numbers, would be nice
     # to generate them too, but we have coverage for remove_integer()
     # verifying that it doesn't accept them, so meh.
     # Test all numbers around the ones that can show up (around order)

--- a/versioneer.py
+++ b/versioneer.py
@@ -179,7 +179,7 @@ two common reasons why `setup.py` might not be in the root:
   `setup.cfg`, and `tox.ini`. Projects like these produce multiple PyPI
   distributions (and upload multiple independently-installable tarballs).
 * Source trees whose main purpose is to contain a C library, but which also
-  provide bindings to Python (and perhaps other langauges) in subdirectories.
+  provide bindings to Python (and perhaps other languages) in subdirectories.
 
 Versioneer will look for `.git` in parent directories, and most operations
 should get the right version string. However `pip` and `setuptools` have bugs


### PR DESCRIPTION
There are small typos in:
- src/ecdsa/ellipticcurve.py
- src/ecdsa/numbertheory.py
- src/ecdsa/test_malformed_sigs.py
- versioneer.py

Fixes:
- Should read `support` rather than `suport`.
- Should read `languages` rather than `langauges`.
- Should read `internally` rather than `interanlly`.
- Should read `arbitrarily` rather than `arbitrarly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md