### PR TITLE
add note to not use low level interfaces

### DIFF
--- a/src/ecdsa/ecdsa.py
+++ b/src/ecdsa/ecdsa.py
@@ -3,6 +3,9 @@
 """
 Implementation of Elliptic-Curve Digital Signatures.
 
+NOTE: This a low level implementation of ECDSA, for normal applications
+you should be looking at the keys.py module.
+
 Classes and methods for elliptic-curve signatures:
 private keys, public keys, signatures,
 NIST prime-modulus curves with modulus lengths of


### PR DESCRIPTION
While it's natural to look at the ecdsa module, users shouldn't use it to implement ECDSA in their applications, add a note redirecting them to the appropriate keys module.

See also #95 