### PR TITLE
try to support pkcs8 v2 format pem file for EdDSA

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -1124,10 +1124,16 @@ class SigningKey(object):
                         "Non NULL parameters for a EdDSA key"
                     )
                 key_str_der, s = der.remove_octet_string(s)
-                if s:
-                    raise der.UnexpectedDER(
-                        "trailing junk inside the privateKey"
-                    )
+                
+                # As RFC5958 describe, there are may be optional Attributes 
+                # and Publickey. Don't raise error if something after 
+                # Privatekey
+                
+                # TODO parse attributes or validate publickey
+                # if s:
+                #     raise der.UnexpectedDER(
+                #         "trailing junk inside the privateKey"
+                #     )
                 key_str, s = der.remove_octet_string(key_str_der)
                 if s:
                     raise der.UnexpectedDER(

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -1124,11 +1124,11 @@ class SigningKey(object):
                         "Non NULL parameters for a EdDSA key"
                     )
                 key_str_der, s = der.remove_octet_string(s)
-                
-                # As RFC5958 describe, there are may be optional Attributes 
-                # and Publickey. Don't raise error if something after 
+
+                # As RFC5958 describe, there are may be optional Attributes
+                # and Publickey. Don't raise error if something after
                 # Privatekey
-                
+
                 # TODO parse attributes or validate publickey
                 # if s:
                 #     raise der.UnexpectedDER(

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -928,11 +928,12 @@ def test_VerifyingKey_inequality_with_different_secret_points():
 
     assert sk1.verifying_key != sk2.verifying_key
 
-def test_SigningKey_from_pem_pkcs8v2():
+def test_SigningKey_from_pem_pkcs8v2_EdDSA():
     pem = """-----BEGIN PRIVATE KEY-----
     MFMCAQEwBQYDK2VwBCIEICc2F2ag1n1QP0jY+g9qWx5sDkx0s/HdNi3cSRHw+zsI
     oSMDIQA+HQ2xCif8a/LMWR2m5HaCm5I2pKe/cc8OiRANMHxjKQ==
     -----END PRIVATE KEY-----"""
     
     sk = SigningKey.from_pem(pem)
+    assert sk.curve == Ed25519
     

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -927,3 +927,12 @@ def test_VerifyingKey_inequality_with_different_secret_points():
     sk2 = SigningKey.from_secret_exponent(3, BRAINPOOLP160r1)
 
     assert sk1.verifying_key != sk2.verifying_key
+
+def test_SigningKey_from_pem_pkcs8v2():
+    pem = """-----BEGIN PRIVATE KEY-----
+    MFMCAQEwBQYDK2VwBCIEICc2F2ag1n1QP0jY+g9qWx5sDkx0s/HdNi3cSRHw+zsI
+    oSMDIQA+HQ2xCif8a/LMWR2m5HaCm5I2pKe/cc8OiRANMHxjKQ==
+    -----END PRIVATE KEY-----"""
+    
+    sk = SigningKey.from_pem(pem)
+    

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -928,12 +928,12 @@ def test_VerifyingKey_inequality_with_different_secret_points():
 
     assert sk1.verifying_key != sk2.verifying_key
 
+
 def test_SigningKey_from_pem_pkcs8v2_EdDSA():
     pem = """-----BEGIN PRIVATE KEY-----
     MFMCAQEwBQYDK2VwBCIEICc2F2ag1n1QP0jY+g9qWx5sDkx0s/HdNi3cSRHw+zsI
     oSMDIQA+HQ2xCif8a/LMWR2m5HaCm5I2pKe/cc8OiRANMHxjKQ==
     -----END PRIVATE KEY-----"""
-    
+
     sk = SigningKey.from_pem(pem)
     assert sk.curve == Ed25519
-    


### PR DESCRIPTION
Try to fix #280. 

[RFC5958](https://datatracker.ietf.org/doc/html/rfc5958#section-2) shows that pkcs8 v2 has the format:
```
OneAsymmetricKey ::= SEQUENCE {
       version                   Version,
       privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
       privateKey                PrivateKey,
       attributes            [0] Attributes OPTIONAL,
       ...,
       [[2: publicKey        [1] PublicKey OPTIONAL ]],
       ...
}
```
There are maybe optional Attributes and Publickey after Privatekey.  Thus it may not raise error when there are trailing data.