### PR TITLE
workaround py3.3 bug with empty strings and memoryview

### DIFF
--- a/src/ecdsa/_compat.py
+++ b/src/ecdsa/_compat.py
@@ -100,17 +100,23 @@ else:
                 return bytes(data)
             return data
 
+        def normalise_bytes(buffer_object):
+            """Cast the input into array of bytes."""
+            if not buffer_object:
+                return b""
+            return memoryview(buffer_object).cast("B")
+
     else:
 
         def hmac_compat(data):
             return data
 
+        def normalise_bytes(buffer_object):
+            """Cast the input into array of bytes."""
+            return memoryview(buffer_object).cast("B")
+
     def compat26_str(val):
         return val
-
-    def normalise_bytes(buffer_object):
-        """Cast the input into array of bytes."""
-        return memoryview(buffer_object).cast("B")
 
     def remove_whitespace(text):
         """Removes all whitespace from passed in string"""

--- a/src/ecdsa/test_keys.py
+++ b/src/ecdsa/test_keys.py
@@ -550,6 +550,15 @@ class TestSigningKey(unittest.TestCase):
         self.assertEqual(self.sk1, sk)
         self.assertEqual(self.sk1_pkcs8, sk)
 
+    def test_verify_with_empty_message(self):
+        sig = self.sk1.sign(b"")
+
+        self.assertTrue(sig)
+
+        vk = self.sk1.verifying_key
+
+        self.assertTrue(vk.verify(sig, b""))
+
     def test_verify_with_precompute(self):
         sig = self.sk1.sign(b"message")
 


### PR DESCRIPTION
Python 3.3 refuses to cast an empty byte string back to bytes, so return an empty byte string manually.