### PR TITLE
[Docs] Add warning that this is not intended for production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ also agree on a shared secret key based on exchanged public keys.
 The keys and signatures are very short, making them easy to handle and
 incorporate into other protocols.
 
-**NOTE: This library should not be used in production settings, see [Security](#Security) for more details**
+**NOTE: This library should not be used in production settings, see [Security](#Security) for more details.**
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ also agree on a shared secret key based on exchanged public keys.
 The keys and signatures are very short, making them easy to handle and
 incorporate into other protocols.
 
+**NOTE: This library should not be used in production settings, see [Security](#Security) for more details**
+
 ## Features
 
 This library provides key generation, signing, verifying, and shared secret


### PR DESCRIPTION
Hey! I was looking for an ECDSA library for my python application and this came up as the first option. It was not super apparent that it is _not intended for production_ use (i.e. it is vulnerable to side channel attacks) and I thought it warranted mentioning this up front. 

I want to be clear, I really appreciate that this library walks through the signing algorithms in an easy-to-understand manner and is much friendlier that staring at C implementations 😄!