### PR TITLE
explicit curve encoding fixes

### DIFF
--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -629,7 +629,7 @@ class VerifyingKey(object):
             implementations, it is as big as "uncompressed".
         :param str curve_parameters_encoding: the encoding for curve parameters
             to use, by default tries to use ``named_curve`` encoding,
-            if that is not possible, falls back to ``named_curve`` encoding.
+            if that is not possible, falls back to ``explicit`` encoding.
 
         :return: portable encoding of the public key
         :rtype: bytes
@@ -658,7 +658,7 @@ class VerifyingKey(object):
             implementations, it is as big as "uncompressed".
         :param str curve_parameters_encoding: the encoding for curve parameters
             to use, by default tries to use ``named_curve`` encoding,
-            if that is not possible, falls back to ``named_curve`` encoding.
+            if that is not possible, falls back to ``explicit`` encoding.
 
         :return: DER encoding of the public key
         :rtype: bytes

--- a/src/ecdsa/keys.py
+++ b/src/ecdsa/keys.py
@@ -674,7 +674,7 @@ class VerifyingKey(object):
         return der.encode_sequence(
             der.encode_sequence(
                 encoded_oid_ecPublicKey,
-                self.curve.to_der(curve_parameters_encoding),
+                self.curve.to_der(curve_parameters_encoding, point_encoding),
             ),
             # 0 is the number of unused bits in the
             # bit string


### PR DESCRIPTION
* fix the documentation to list the two valid encoding formats
* Allow the user to control the encoding format of the curve generator when exporting public key with explicit parameters