### PR TITLE
better handling for malformed curve parameters

### DIFF
--- a/src/ecdsa/ellipticcurve.py
+++ b/src/ecdsa/ellipticcurve.py
@@ -260,7 +260,7 @@ class AbstractPoint(object):
         alpha = (pow(x, 3, p) + (curve.a() * x) + curve.b()) % p
         try:
             beta = numbertheory.square_root_mod_prime(alpha, p)
-        except numbertheory.SquareRootError as e:
+        except numbertheory.Error as e:
             raise MalformedPointError(
                 "Encoding does not correspond to a point on curve", e
             )
@@ -315,7 +315,7 @@ class AbstractPoint(object):
 
         try:
             x = numbertheory.square_root_mod_prime(x2, p)
-        except numbertheory.SquareRootError as e:
+        except numbertheory.Error as e:
             raise MalformedPointError(
                 "Encoding does not correspond to a point on curve", e
             )

--- a/src/ecdsa/numbertheory.py
+++ b/src/ecdsa/numbertheory.py
@@ -43,6 +43,10 @@ class Error(Exception):
     pass
 
 
+class JacobiError(Error):
+    pass
+
+
 class SquareRootError(Error):
     pass
 
@@ -154,8 +158,10 @@ def jacobi(a, n):
     # table printed in HAC, and by extensive use in calculating
     # modular square roots.
 
-    assert n >= 3
-    assert n % 2 == 1
+    if not n >= 3:
+        raise JacobiError("n must be larger than 2")
+    if not n % 2 == 1:
+        raise JacobiError("n must be odd")
     a = a % n
     if a == 0:
         return 0
@@ -202,9 +208,8 @@ def square_root_mod_prime(a, p):
         d = pow(a, (p - 1) // 4, p)
         if d == 1:
             return pow(a, (p + 3) // 8, p)
-        if d == p - 1:
-            return (2 * a * pow(4 * a, (p - 5) // 8, p)) % p
-        raise RuntimeError("Shouldn't get here.")
+        assert d == p - 1
+        return (2 * a * pow(4 * a, (p - 5) // 8, p)) % p
 
     if PY2:
         # xrange on python2 can take integers representable as C long only
@@ -215,7 +220,8 @@ def square_root_mod_prime(a, p):
         if jacobi(b * b - 4 * a, p) == -1:
             f = (a, -b, 1)
             ff = polynomial_exp_mod((0, 1), (p + 1) // 2, f, p)
-            assert ff[1] == 0
+            if ff[1]:
+                raise SquareRootError("p is not prime")
             return ff[0]
     raise RuntimeError("No b found.")
 

--- a/src/ecdsa/test_numbertheory.py
+++ b/src/ecdsa/test_numbertheory.py
@@ -17,6 +17,7 @@ except ImportError:  # pragma: no cover
     HC_PRESENT = False
 from .numbertheory import (
     SquareRootError,
+    JacobiError,
     factorization,
     gcd,
     lcm,
@@ -106,6 +107,30 @@ def test_square_root_mod_prime_for_p_congruent_5_large_d():
 
     root = square_root_mod_prime(4, p)
     assert root * root % p == 4
+
+
+class TestSquareRootModPrime(unittest.TestCase):
+    def test_power_of_2_p(self):
+        with self.assertRaises(JacobiError):
+            square_root_mod_prime(12, 32)
+
+    def test_no_square(self):
+        with self.assertRaises(SquareRootError) as e:
+            square_root_mod_prime(12, 31)
+
+        self.assertIn("no square root", str(e.exception))
+
+    def test_non_prime(self):
+        with self.assertRaises(SquareRootError) as e:
+            square_root_mod_prime(12, 33)
+
+        self.assertIn("p is not prime", str(e.exception))
+
+    def test_non_prime_with_negative(self):
+        with self.assertRaises(SquareRootError) as e:
+            square_root_mod_prime(697 - 1, 697)
+
+        self.assertIn("p is not prime", str(e.exception))
 
 
 @st.composite


### PR DESCRIPTION
Since explicit curve parameters may not use prime numbers as the field
(see CVE-2022-0778), make sure that our square_root_mod_prime()
handles non-prime p gracefully