### PR TITLE
Fix test `test_SigningKey_from_pem_pkcs8v2_EdDSA` with new Python

### DIFF
--- a/src/ecdsa/der.py
+++ b/src/ecdsa/der.py
@@ -464,12 +464,11 @@ def unpem(pem):
     if isinstance(pem, text_type):  # pragma: no branch
         pem = pem.encode()
 
+    lines = (l.strip() for l in pem.split(b"\n"))
     d = b"".join(
-        [
-            l.strip()
-            for l in pem.split(b"\n")
-            if l and not l.startswith(b"-----")
-        ]
+        l
+        for l in lines
+        if l and not l.startswith(b"-----")
     )
     return base64.b64decode(d)
 


### PR DESCRIPTION
Test `test_SigningKey_from_pem_pkcs8v2_EdDSA` fail with Python 3.13.13 or 3.14.4

pem from tests - https://github.com/tlsfuzzer/python-ecdsa/blob/master/src/ecdsa/test_keys.py#L1132-L1135
```
....-----BEGIN PRIVATE KEY-----
....MFMCAQEwBQYDK2VwBCIEICc2F2ag1n1QP0jY+g9qWx5sDkx0s/HdNi3cSRHw+zsI
....oSMDIQA+HQ2xCif8a/LMWR2m5HaCm5I2pKe/cc8OiRANMHxjKQ==
....-----END PRIVATE KEY-----
```
last line contain leading spaces and not skipped in old version `unpem` and  in `base64.b64decode(d)`
```
d = b"MFM...KQ==-----END PRIVATE KEY-----"
```
Python 3.13.12 or 3.14.3 skip extra chars after padding, but after https://github.com/python/cpython/issues/145264 (Python 3.13.13 or 3.14.4), this is not the case, now raise `binascii.Error: Incorrect padding`